### PR TITLE
Update install-test-sh

### DIFF
--- a/install-test-sh
+++ b/install-test-sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 #python test-depend.py
-cd utest
-nosetests testAlgos.py -v
+cd mosaic/utest/
+nosetests mosaicTests.py -v


### PR DESCRIPTION
Updated outdated reference in install-test-sh to TestAlgos - replaced with correct location and file name (mosaicTests.py). Verified this works.
