### PR TITLE
fixed bug in settings data type

### DIFF
--- a/mosaic/cusumLevelAnalysis.py
+++ b/mosaic/cusumLevelAnalysis.py
@@ -84,7 +84,7 @@ class cusumLevelAnalysis(metaEventProcessor.metaEventProcessor):
 		# Settings for detection of changed in current level
 		try:
 			self.StepSize=float(self.settingsDict.pop("StepSize", 3.0))
-			self.Threshold=int(self.settingsDict.pop("Threshold", 3.0))
+			self.Threshold=float(self.settingsDict.pop("Threshold", 3.0))
 		except ValueError as err:
 			raise commonExceptions.SettingsTypeError( err )
 


### PR DESCRIPTION
threshold should be a float, not an int. This was probably causing it to
default to a bad value up until now, making testing potentially useless depending on what value it was defaulting to when given a float.