### PR TITLE
added option for very fast CUSUM which will perform a fast but low accur...

### DIFF
--- a/mosaic/cusumLevelAnalysis.py
+++ b/mosaic/cusumLevelAnalysis.py
@@ -254,7 +254,7 @@ class cusumLevelAnalysis(metaEventProcessor.metaEventProcessor):
                                 varOldM = varM #algorithm to calculate running variance, details here: http://www.johndcook.com/blog/standard_deviation/
                                 varM = varM + (edat[k] - varM)/float(k+1-anchor)
                                 varS = varS + (edat[k] - varOldM) * (edat[k] - varM)
-                                varS / float(k+1-anchor)
+                                variance = varS / float(k+1-anchor)
                                 mean = ((k-anchor) * mean + edat[k])/float(k+1-anchor)
                                 if (variance == 0):                 # with low-precision data sets it is possible that two adjacent values are equal, in which case there is zero variance for the two-vector of sample if this occurs next to a detected jump. This is very, very rare, but it does happen.
                                         variance = self.baseSD*self.baseSD # in that case, we default to the local baseline variance, which is a good an estimate as any.


### PR DESCRIPTION
...acy analysis of a file.

To achieve the speedup requires that we assume that the local variance during an event is the same as the baseline variance. This seems to work reasonably well for very long (>10RC) events, but distorts short ones even more than usual.

The faster option changes CUSUM scaling from O(N^2) to O(N), so speed gains should be even greater on long events.

This requires some additional testing to ascertain the effects of assuming a constant variance.

The fast mode can be activated in the code by adding a new setting called "UseLocalVariance" to the settings dict. 1 means use the regular cusum, 0 means use fast mode.

