### PR TITLE
fixed error handling bug that was reraising exceptions and causing a crash

### DIFF
--- a/mosaic/adept2State.py
+++ b/mosaic/adept2State.py
@@ -269,7 +269,6 @@ class adept2State(metaEventProcessor.metaEventProcessor):
 		except:
 			# print optfit.message, optfit.lmdif_message
 	 		self.rejectEvent('eFitFailure')
-	 		raise
 
 			
 	


### PR DESCRIPTION
bug fix for adept2state - windows version would crash if curve_fit raised an unhandled exception instead of simply rejecting the event