### PR TITLE
Devel 1 0 ticket69

### DIFF
--- a/mosaic/eventSegment.py
+++ b/mosaic/eventSegment.py
@@ -8,6 +8,7 @@
 	:License:	See LICENSE.TXT
 	:ChangeLog:
 	.. line-block::
+                15/12/15        KB      Bug fixes to baseline recalculation
 		12/12/15	AB 	Recalculate baseline currents when drift checks are disabled and baseline detection is set to automatic.
 		12/11/15 	AB 	Refactor code
 		5/17/14		AB  Delete plotting support

--- a/mosaic/eventSegment.py
+++ b/mosaic/eventSegment.py
@@ -77,6 +77,10 @@ class eventSegment(metaEventPartition.metaEventPartition):
 			self.meanOpenCurr=float(self.settingsDict.pop("meanOpenCurr",-1.))
 			self.sdOpenCurr=float(self.settingsDict.pop("sdOpenCurr",-1.))
 			self.slopeOpenCurr=float(self.settingsDict.pop("slopeOpenCurr",-1.))
+			self.minBaseline=float(self.settingsDict.pop("minBaseline",-1.))
+			self.maxBaseline=float(self.settingsDict.pop("maxBaseline",-1.))
+			print self.maxBaseline
+			print self.minBaseline
 		except ValueError as err:
 			raise commonExceptions.SettingsTypeError( err )
 

--- a/mosaic/metaEventPartition.py
+++ b/mosaic/metaEventPartition.py
@@ -7,6 +7,7 @@
 	:License:	See LICENSE.TXT
 	:ChangeLog:
 	.. line-block::
+                15/12/15        KB      Program steps over bad data blocks without aborting
 		12/11/15 	AB 	Refactor code
 		12/6/15 	AB 	Add sampling frequency to analysis info table
 		8/18/14		AB 	Fixed parallel processing cleanup.

--- a/mosaic/metaEventPartition.py
+++ b/mosaic/metaEventPartition.py
@@ -180,7 +180,10 @@ class metaEventPartition(object):
 				#print self.meanOpenCurr, self.minDrift, self.maxDrift, self.minDriftR, self.maxDriftR
 
 				# Process the data segment for events
-				self._eventsegment()
+				if (self.meanOpenCurr > self.minBaseline and self.meanOpenCurr < self.maxBaseline) or self.minBaseline == -1.0 or self.maxBaseline == -1.0:
+                                        self._eventsegment()
+                                else: #skip over bad data, no need to abort
+                                        continue
 
 
 		except metaTrajIO.EmptyDataPipeError, err:
@@ -463,7 +466,7 @@ class metaEventPartition(object):
 		#print "nPoints=", n, "len(tstamp)=", len(tstamp), "type(curr)", type(curr)
 		
 		# Calculate the mean and standard deviation of the open state
-		mu, sig=OpenCurrentDist(curr, 0.5)
+		mu, sig=OpenCurrentDist(curr, 0.5, self.minBaseline, self.maxBaseline)
 
 		# Fit the data to a straight line to calculate the slope
 		# ft[0]: slope

--- a/mosaic/utilities/ionic_current_stats.py
+++ b/mosaic/utilities/ionic_current_stats.py
@@ -8,8 +8,9 @@
 """
 import numpy as np 
 from scipy.optimize import curve_fit
+import pylab as pl
 
-def OpenCurrentDist(dat, limit):
+def OpenCurrentDist(dat, limit, minBaseline, maxBaseline):
 	"""
 		Calculate the mean and standard deviation of a time-series.
 		
@@ -28,12 +29,18 @@ def OpenCurrentDist(dat, limit):
 	def _fitfunc(x, a, s, m):
 		return a*np.exp(-(x-m)**2/(2. * s**2))
 
-	y,x=np.histogram(uDat, range=hLimit, bins=100)
+        if minBaseline == -1.0 or maxBaseline == -1.0:
+                y,x=np.histogram(uDat, range=hLimit, bins=100)
+                
+        else:
+                y,x=np.histogram(uDat, range=[minBaseline, maxBaseline], bins=100)
 	try:
 		popt, pcov = curve_fit(_fitfunc, x[:-1], y, p0=[np.max(y), dStd, np.mean(x)])
 		perr=np.sqrt(np.diag(pcov))
 	except:
 		return [0,0]
+	if np.any(perr/popt > 0.5): #0.5 is arbitrary for the moment, for testing. Could be added as a parameter or hard-coded pending testing. 
+                return [0,0]
 
 	return [popt[2], np.abs(popt[1])]
 

--- a/mosaic/utilities/ionic_current_stats.py
+++ b/mosaic/utilities/ionic_current_stats.py
@@ -4,6 +4,7 @@
 	:License:	See LICENSE.TXT	
 	:ChangeLog:
 	.. line-block::
+                15/12/15        KB      Added error checking and limits to baseline calculations
 		10/30/14	AB	Initial version
 """
 import numpy as np 


### PR DESCRIPTION
Added baseline limits to the settings required for EventSegment. If those parameters (minBaseline and maxBaseline) are not supplied,
program defaults to old behaviour.

Implemented some error checking in OpenCurrentDist() - previously, if there was a clog in the data block the curve_fit could return garbage well outside the reasonable range, but mosaic would continue with the bad data. In some cases this could cause mosaic to get bogged down fitting events to every single data point in a clogged block and it would never finish. This was not a problem before when baseline was calculated once at the start, but with a continuous update extra error checking is required. The error check implemented just checks that the stadnard errors are less than 50% of the fitting estimates themselves, which is enough to eliminate most of the bad blocks.  

I also set the program to step over and ignore blocks with bad baseline stats, rather than aborting directly. This behavior might be something to think about doing for the drift checks later as well, since it reduces the need for use supervision.

Still needs testing, but this shows some improvement for the test data set I am working with so far. 