### PR TITLE
Devel 1 0 minstep

### DIFF
--- a/mosaic/adept.py
+++ b/mosaic/adept.py
@@ -133,7 +133,7 @@ class adept(metaEventProcessor.metaEventProcessor):
 				edat=self.dataPolarity*np.asarray( self.eventData,  dtype='float64' )
 
 				# estimate initial guess for events
-				initguess=self._cusumInitGuess(self.eventData)
+				initguess=self._cusumInitGuess(edat)
 				
 				# Fit the system transfer function to the event data
 				# if sys.platform.startswith('win'):


### PR DESCRIPTION
cusum was using raw data for initial guess, then adept was suing polarity-adjusted data. It doesn't make much difference for this data set, but better to use the same data for both